### PR TITLE
Adding disconnect_message Confirmation (Issue #1502)

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1047,6 +1047,10 @@ const UI = {
     },
 
     disconnect() {
+        // When parameter disconnect_message is set, it will show a message to confirm the disconection being its value the text on the confirm dialog
+        if (WebUtil.getConfigVar('disconnect_message', false) && confirm( WebUtil.getConfigVar('disconnect_message') ) == false ) {
+            return;
+        }
         UI.rfb.disconnect();
 
         UI.connected = false;


### PR DESCRIPTION
When parameter disconnect_message is set, it will show a message to confirm the disconnection being its value the text on the confirm dialog.

This is related to the issue #1502 "two-step 'disconnect' option with custom message  "

Example:
vnc.html?disconnect_message=Disconnecting%20does%20not%20close%20the%20remote%20session

